### PR TITLE
Disable nginx caching header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -29,9 +29,5 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
-
-    location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {
-      expires 1d;
-    }
   }
 }


### PR DESCRIPTION
Is was causing problems when displaying content using Angular.
Instread of actual data, fields names like 'login.username' was displayed.